### PR TITLE
✨ feat: Send .npy and .json to backend server

### DIFF
--- a/utils/send_server.py
+++ b/utils/send_server.py
@@ -1,0 +1,15 @@
+import requests
+import json
+
+def send_model(from_path,to_path):
+    answer_embed = open(from_path + 'answer_embedding_matrix.npy','rb')
+    with open(from_path+'question_cate_map_answerid.json', 'r') as f:
+        question_answer_map = json.load(f)
+    question_answer_map = json.dumps(question_answer_map)
+    upload = {'answer_embedding':answer_embed}
+    jsons = {'question_answer_mapping_json':question_answer_map}
+    res = requests.post(to_path, files = upload, data=jsons)
+    print('send complete')
+
+if __name__ == '__main__':   
+    send_model("../pickle/",'http://www.recommendu.kro.kr:30001/services/save_embedding/')


### PR DESCRIPTION
## 개요
ETL에 만들어진 데이터 중에 서버로 바로 보낼 파일을 api를 통해 업데이트 해주는 로직을 구현
- #24 
## 작업사항
파일을 보내기 위해 files에 받을 수 있도록 구현했고,  json파일은 data에 받을 수 있도록 구성함
```
upload = {'answer_embedding':answer_embed}
jsons = {'question_answer_mapping_json':question_answer_map}
res = requests.post(to_path, files = upload, data=jsons)
```